### PR TITLE
Updated forms.py to use ssl for recaptcha.

### DIFF
--- a/pygraz_website/apps/meetups/forms.py
+++ b/pygraz_website/apps/meetups/forms.py
@@ -12,7 +12,7 @@ from . import models
 class AnonymousSessionSubmissionForm(forms.ModelForm):
     speaker_name = forms.CharField(required=True, label="Dein Name")
     speaker_email = forms.EmailField(required=True, label="Deine E-Mail-Adresse")
-    captcha = ReCaptchaField(attrs={'theme': 'white'})
+    captcha = ReCaptchaField(attrs={'theme': 'white'}, use_ssl=True)
 
     class Meta(object):
         model = models.Session


### PR DESCRIPTION
This is required in up2date firefox versions since it will block unsafe content by default.
