### PR TITLE
Upgrade psycopg2 to 2.7.x

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Django==1.8.3
 Fabric==1.10.1
-psycopg2==2.6
+psycopg2==2.7.4
 pytz==2015.2
 wsgiref==0.1.2
 django-crispy-forms==1.4.0


### PR DESCRIPTION
As some environments are now already using PostgreSQL 10.x we have to
upgrade psycopg2 as older versions had a bug parsing the version string
beyond PostgreSQL 9.x.